### PR TITLE
feat: ✨ added automatic extraction of .wabbajack files, GUI and GitHub action to compile into EXE and put out a release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  FILE_NAME: Wabbajack-downloader-windows-${{ github.ref_name }}
+
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -24,7 +27,7 @@ jobs:
           onefile: 'true'
           enable-plugins: 'tk-inter'
           windows-console-mode: 'disable'
-          output-file: Wabbajack-downloader-windows-${{ github.ref_name }}.exe
+          output-file: $FILE_NAME.exe
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -33,4 +36,4 @@ jobs:
             ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
-          files: Wabbajack-downloader-windows-${{ github.ref_name }}.exe
+          files: build/$FILE_NAME.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
           nuitka-version: 'main'
           script-name: gui.py
           onefile: 'true'
+          enable-plugins: 'tk-inter'
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -34,8 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.event.release.tag_name }}
-          release_name: ${{ github.event.head_commit.message }}
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
           body: |
             ${{ github.event.head_commit.message }}
           draft: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           architecture: 'x64'
       - name: Build with Nuitka
         uses: Nuitka/Nuitka-Action@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,5 +50,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: build/gui.exe
-          asset_name: Wabbajack-downloader-windows-${{ github.event.repository.tag_name }}.exe
+          asset_name: Wabbajack-downloader-windows-${{ github.ref_name }}.exe
           asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Build with Nuitka
         uses: Nuitka/Nuitka-Action@main
@@ -24,31 +24,13 @@ jobs:
           onefile: 'true'
           enable-plugins: 'tk-inter'
           windows-console-mode: 'disable'
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-latest Build
-          path: | 
-            build/*.exe
+          output-file: Wabbajack-downloader-windows-${{ github.ref_name }}.exe
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
           body: |
             ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/gui.exe
-          asset_name: Wabbajack-downloader-windows-${{ github.ref_name }}.exe
-          asset_content_type: application/octet-stream
+          files: Wabbajack-downloader-windows-${{ github.ref_name }}.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build Workflow
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 jobs:
   build-windows:
@@ -28,15 +28,14 @@ jobs:
           name: windows-latest Build
           path: | 
             build/*.exe
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.event.repository.tag_name }}
-          release_name: ${{ github.event.repository.tag_name }}
+          tag_name: ${{ github.event.release.tag_name }}
+          release_name: ${{ github.event.head_commit.message }}
           body: |
             ${{ github.event.head_commit.message }}
           draft: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+name: Build Workflow
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.12'
+          architecture: 'x64'
+      - name: Build with Nuitka
+        uses: Nuitka/Nuitka-Action@main
+        with:
+          nuitka-version: 'main'
+          script-name: gui.py
+          onefile: 'true'
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-latest Build
+          path: | 
+            build/*.exe
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.repository.tag_name }}
+          release_name: ${{ github.event.repository.tag_name }}
+          body: |
+            ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/*.exe
+          asset_name: Wabbajack-downloader-windows-${{ github.event.repository.tag_name }}.exe
+          asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           script-name: gui.py
           onefile: 'true'
           enable-plugins: 'tk-inter'
+          windows-console-mode: 'disable'
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -48,6 +49,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/*.exe
+          asset_path: build/gui.exe
           asset_name: Wabbajack-downloader-windows-${{ github.event.repository.tag_name }}.exe
           asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           onefile: 'true'
           enable-plugins: 'tk-inter'
           windows-console-mode: 'disable'
-          output-file: $FILE_NAME.exe
+          output-file: ${{ env.FILE_NAME }}.exe
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -36,4 +36,4 @@ jobs:
             ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
-          files: build/$FILE_NAME.exe
+          files: build/${{ env.FILE_NAME }}.exe

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 > **Project Origin:** This project was inspired by the need for a faster mod downloading process for Wabbajack-generated modlists, originating from [this GitHub issue](https://github.com/parsiad/nexus-autodl/issues/17).
 
+## Executable Usage
+
+1. Download the executable from [here](https://github.com/DassaultMirage2K/Wabbajack-fast-downloader-GUI/releases)
+
+2. Run the executable
+
+3. Select the '*.wabbajack' modlist file
+
+4. Click 'Extract'
+
+5. Click 'Batch Download' to download links in batches
+
 ## How It Works
 
 1. **Modlist Extraction:** Parses the JSON modlist file to extract mod IDs and file IDs, generating download links for each mod on Nexus Mods.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 > **Project Origin:** This project was inspired by the need for a faster mod downloading process for Wabbajack-generated modlists, originating from [this GitHub issue](https://github.com/parsiad/nexus-autodl/issues/17).
 
+## How It Works
+
+1. **Modlist Extraction:** Parses the JSON modlist file to extract mod IDs and file IDs, generating download links for each mod on Nexus Mods.
+2. **Batch Download:** Opens the generated download links in batches using the `webbrowser` module to bypass download limits and speed up the process.
+
 ## Executable Usage
 
-1. Download the executable from [here](https://github.com/DassaultMirage2K/Wabbajack-fast-downloader-GUI/releases)
+1. Download the executable from [here](https://github.com/M1n-74316D65/Wabbajack-fast-downloader/releases)
 
 2. Run the executable
 
@@ -15,11 +20,6 @@
 4. Click 'Extract'
 
 5. Click 'Batch Download' to download links in batches
-
-## How It Works
-
-1. **Modlist Extraction:** Parses the JSON modlist file to extract mod IDs and file IDs, generating download links for each mod on Nexus Mods.
-2. **Batch Download:** Opens the generated download links in batches using the `webbrowser` module to bypass download limits and speed up the process.
 
 ## Requirements
 

--- a/gui.py
+++ b/gui.py
@@ -52,13 +52,6 @@ def update_progress_bar_value():
 
 
 def import_links():
-    """
-    Imports URLs from the 'output.txt' file and initializes the download process.
-
-    This function reads URLs from 'output.txt' using a batch process. The progress bar
-    is updated based on the total number of URLs. If the file is successfully read,
-    the console will display the total number of URLs imported.
-    """
     global links_amount
     global processed_links
     global generator
@@ -66,6 +59,9 @@ def import_links():
     try:
         console.print("Importing URLs from output.txt file...")
         links_amount = batch_download.count_lines(output_file_path)
+        if links_amount == 0:
+            console.print("No URLs found in output.txt file.")
+            return
         generator = batch_download.read_links_in_batches(output_file_path, 20)
         progress['maximum'] = links_amount
         update_progress_bar_value()
@@ -117,8 +113,9 @@ def browse_file():
     file path entry box with the selected file's path.
     """
     filename = filedialog.askopenfilename(filetypes=[("Wabbajack mod list file", "*.wabbajack")])
-    file_path_entrybox.delete(0, tk.END)
-    file_path_entrybox.insert(tk.END, filename)  # add this
+    if filename != "":
+        file_path_entrybox.delete(0, tk.END)
+        file_path_entrybox.insert(tk.END, filename)
 
 
 def extract_file():
@@ -167,6 +164,7 @@ def extract_url(modlist_file):
 
     console.print(f"Writing URLs to {output_file_path}...")
     write_urls_to_file(urls, output_file_path)
+    import_links()
     console.print("Successfully wrote URLs to file.")
 
 
@@ -207,10 +205,11 @@ progress = ttk.Progressbar(root, orient=tk.HORIZONTAL, style='text.Horizontal.TP
                            maximum=links_amount, variable=processed_links)
 progress.place(x=10, y=120)
 
-import_links_button = tk.Button(root, text="Import Links from output.txt file", font=40, command=import_links)
-import_links_button.place(x=10, y=80)
-
 download_batch_button = tk.Button(root, text="Download batch", font=40, command=download_links)
-download_batch_button.place(x=250, y=80)
+download_batch_button.place(x=180, y=80)
+
+if os.path.exists(output_file_path):
+    console.print(f"Found output.txt file.")
+    import_links()
 
 root.mainloop()

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,216 @@
+import json
+import os
+import webbrowser
+import zipfile
+import tkinter as tk
+
+import batch_download
+import extract_modlist
+
+from tkinter import filedialog, messagebox, ttk
+
+from extract_modlist import write_urls_to_file
+
+
+class TextScrollCombo(tk.Frame):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # ensure a consistent GUI size
+        self.grid_propagate(False)
+        # implement stretchability
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        # create a Text widget
+        self.txt = ConsoleOutput(self)
+        self.txt.grid(row=0, column=0, sticky="nsew", padx=2, pady=2)
+
+        # create a Scrollbar and associate it with txt
+        scrollb = tk.Scrollbar(self, command=self.txt.yview)
+        scrollb.grid(row=0, column=1, sticky='nsew')
+        self.txt['yscrollcommand'] = scrollb.set
+
+    def print(self, text):
+        self.txt.print(text)
+
+
+class ConsoleOutput(tk.Text):
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.config(state="disabled")
+
+    def print(self, text):
+        self.config(state="normal")
+        self.insert(tk.END, text + "\n")
+        self.see(tk.END)
+        self.config(state="disabled")
+
+
+def update_progress_bar_value():
+    s.configure('text.Horizontal.TProgressbar',
+                text=f"{processed_links.get()}/{links_amount}")
+
+
+def import_links():
+    """
+    Imports URLs from the 'output.txt' file and initializes the download process.
+
+    This function reads URLs from 'output.txt' using a batch process. The progress bar
+    is updated based on the total number of URLs. If the file is successfully read,
+    the console will display the total number of URLs imported.
+    """
+    global links_amount
+    global processed_links
+    global generator
+    processed_links.set(0)
+    try:
+        console.print("Importing URLs from output.txt file...")
+        links_amount = batch_download.count_lines(output_file_path)
+        generator = batch_download.read_links_in_batches(output_file_path, 20)
+        progress['maximum'] = links_amount
+        update_progress_bar_value()
+        console.print(f"Imported {links_amount} URLs.")
+    except FileNotFoundError:
+        print(f"Error: The file {output_file_path} was not found.")
+    except Exception as e:
+        console.print(f"Error importing URLs: {e}")
+
+
+def download_links():
+    """
+    Downloads the URLs from the generator.
+
+    This function retrieves a batch of URLs from the generator and downloads them
+    using the webbrowser module. The progress bar is updated accordingly.
+
+    If no URLs are available for download, an error message is printed to the console.
+    """
+    global links_amount
+    global processed_links
+    if generator is None:
+        console.print("No URLs to download. Please import URLs from output.txt first.")
+        return
+    if links_amount == 0 or processed_links.get() == links_amount:
+        console.print("No URLs to open.")
+        return
+    batch_links = get_batch()
+    for link in batch_links:
+        webbrowser.open(link)
+        processed_links.set(processed_links.get() + 1)
+    update_progress_bar_value()
+    console.print(f"Opened {processed_links.get()} out of {links_amount} URLs.")
+
+
+def get_batch():
+    """
+    Returns a batch of URLs from the generator.
+    """
+    try:
+        return next(generator)
+    except StopIteration:
+        return []
+
+
+def browse_file():
+    """
+    Opens a file dialog to select a Wabbajack mod list file, updates the
+    file path entry box with the selected file's path.
+    """
+    filename = filedialog.askopenfilename(filetypes=[("Wabbajack mod list file", "*.wabbajack")])
+    file_path_entrybox.delete(0, tk.END)
+    file_path_entrybox.insert(tk.END, filename)  # add this
+
+
+def extract_file():
+    """
+    Extracts the 'modlist' file from the selected Wabbajack zip file and processes its content.
+
+    This function retrieves the file path from the entry box, opens the selected zip file,
+    and extracts the 'modlist' file. The extracted JSON content is then passed to the
+    'extract_url' function for further processing. If any exception occurs during this
+    process, an error message is printed to the console.
+    """
+    try:
+        filename = file_path_entrybox.get()
+        if filename != "":
+            with zipfile.ZipFile(filename, 'r') as zipObj:
+                metadata_name = "modlist"
+                with zipObj.open(metadata_name, 'r') as metadata:
+                    extract_url(json.loads(metadata.read().decode('utf-8').replace("'", '"')))
+    except Exception as e:
+        console.print("Error when extracting a file: " + e.__str__())
+
+
+def extract_url(modlist_file):
+    """
+    Extracts the URLs from the given mod list file and writes them to a file.
+
+    This function takes a mod list file as input and generates URLs from it.
+    The generated URLs are then written to a file called 'output.txt',
+    overwriting any existing file. If the output file already exists, the
+    user is asked if they want to overwrite it.
+
+    :param modlist_file: A JSON object representing the content of a Wabbajack
+        mod list file.
+    :type modlist_file: dict
+    """
+    console.print("Generating URLs from JSON data...")
+    urls = [url for entry in modlist_file.get("Archives", []) if (url := extract_modlist.generate_url(entry))]
+    console.print(f"Generated {len(urls)} URLs.")
+
+    # ask is output file exits
+    if os.path.exists(output_file_path):
+        answer = messagebox.askokcancel("Overwrite", "Do you want to overwrite the output file?")
+        if not answer:
+            console.print("Aborted by user.")
+            return
+
+    console.print(f"Writing URLs to {output_file_path}...")
+    write_urls_to_file(urls, output_file_path)
+    console.print("Successfully wrote URLs to file.")
+
+
+root = tk.Tk()
+root.title('Wabbajack URL Exporter')
+root.geometry('500x500')
+root.resizable(height=False, width=False)
+
+output_file_path = 'output.txt'
+links_amount = 0
+processed_links = tk.IntVar()
+generator = None
+
+console = TextScrollCombo(root, width=500, height=350)
+console.place(y=150, relwidth=1)
+
+file_path_entrybox = tk.Entry(root, font=50, width=35)
+file_path_entrybox.place(x=10, y=32)
+
+import_instruction = tk.Label(root, text="Select a Wabbajack mod list file, then click Import", font=40)
+import_instruction.place(x=10, y=5)
+
+select_wabbajack_file_button = tk.Button(root, text="Select", font=40, command=browse_file)
+select_wabbajack_file_button.place(x=340, y=28)
+import_btn = tk.Button(root, text="Extract", font=40, command=extract_file)
+import_btn.place(x=410, y=28)
+
+s = ttk.Style(root)
+s.layout('text.Horizontal.TProgressbar',
+         [('Horizontal.Progressbar.trough',
+           {'children': [('Horizontal.Progressbar.pbar',
+                          {'side': 'left', 'sticky': 'ns'})],
+            'sticky': 'nswe'}),
+          ('Horizontal.Progressbar.label', {'sticky': 'nswe'})])
+s.configure('text.Horizontal.TProgressbar', text='0/0', anchor='center', )
+
+progress = ttk.Progressbar(root, orient=tk.HORIZONTAL, style='text.Horizontal.TProgressbar', length=450,
+                           maximum=links_amount, variable=processed_links)
+progress.place(x=10, y=120)
+
+import_links_button = tk.Button(root, text="Import Links from output.txt file", font=40, command=import_links)
+import_links_button.place(x=10, y=80)
+
+download_batch_button = tk.Button(root, text="Download batch", font=40, command=download_links)
+download_batch_button.place(x=250, y=80)
+
+root.mainloop()

--- a/gui.py
+++ b/gui.py
@@ -91,7 +91,7 @@ def download_links():
         return
     batch_links = get_batch()
     for link in batch_links:
-        webbrowser.open(link)
+        #webbrowser.open(link)
         processed_links.set(processed_links.get() + 1)
     update_progress_bar_value()
     console.print(f"Opened {processed_links.get()} out of {links_amount} URLs.")
@@ -184,13 +184,15 @@ console.place(y=150, relwidth=1)
 file_path_entrybox = tk.Entry(root, font=50, width=35)
 file_path_entrybox.place(x=10, y=32)
 
-import_instruction = tk.Label(root, text="Select a Wabbajack mod list file, then click Import", font=40)
-import_instruction.place(x=10, y=5)
+
 
 select_wabbajack_file_button = tk.Button(root, text="Select", font=40, command=browse_file)
 select_wabbajack_file_button.place(x=340, y=28)
 import_btn = tk.Button(root, text="Extract", font=40, command=extract_file)
 import_btn.place(x=410, y=28)
+
+import_instruction = tk.Label(root, text=f"Select a Wabbajack mod list file, then click {import_btn.cget('text')}", font=40)
+import_instruction.place(x=10, y=5)
 
 s = ttk.Style(root)
 s.layout('text.Horizontal.TProgressbar',

--- a/gui.py
+++ b/gui.py
@@ -164,8 +164,8 @@ def extract_url(modlist_file):
 
     console.print(f"Writing URLs to {output_file_path}...")
     write_urls_to_file(urls, output_file_path)
-    import_links()
     console.print("Successfully wrote URLs to file.")
+    import_links()
 
 
 root = tk.Tk()


### PR DESCRIPTION
First: I added automatic extraction of `modlist` file inside of `.wabbajack` removing the requirement of extracting it manually.
```python
 with zipfile.ZipFile(filename, 'r') as zipObj:
                metadata_name = "modlist"
                with zipObj.open(metadata_name, 'r') as metadata:
                    extract_url(json.loads(metadata.read().decode('utf-8').replace("'", '"')))
```

Second: I added GUI using tkinter from Python standard library:
![app interface](https://github.com/user-attachments/assets/091fd787-89ba-48df-81d3-3883298f6348)
This added an option to select .wabbajack file from anywhere on the PC

.wabbajack file extract example:
![example 1](https://github.com/user-attachments/assets/66755a3b-b9a6-45a5-8d86-6a7d70a96552)


Download batch opens up web browser like before:
![example 2](https://github.com/user-attachments/assets/9d2ea582-ec61-4099-9461-89b45e669aad)

Third: Added Github action to automatically compile the app and publish on tag push with `v*.*.*` template.  
Example:
https://github.com/DassaultMirage2K/Wabbajack-fast-downloader/releases/tag/v1.0.5
