### PR TITLE
chore(workflow): Switch to PyInstaller and add concurrency control

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           python-version: '3.12'
           architecture: 'x64'
-          cache: 'pip'
       
       - name: Build with PyInstaller
         uses: sayyid5416/pyinstaller@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           python_ver: '3.12'
           spec: 'gui.py'
-          requirements: 'requirements.txt'
           pyinstaller_ver: '==6.3.0'
           exe_path: ./dist
           options: >-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*.*.*'
 
+# Prevent concurrent releases
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -15,28 +20,32 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           architecture: 'x64'
-      - name: Build with Nuitka
-        uses: Nuitka/Nuitka-Action@main
+          cache: 'pip'
+      
+      - name: Build with PyInstaller
+        uses: sayyid5416/pyinstaller@v1
         with:
-          nuitka-version: 'main'
-          script-name: gui.py
-          onefile: 'true'
-          enable-plugins: 'tk-inter'
-          windows-console-mode: 'disable'
-          output-file: ${{ env.FILE_NAME }}.exe
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
+          python_ver: '3.12'
+          spec: 'gui.py'
+          requirements: 'requirements.txt'
+          pyinstaller_ver: '==6.3.0'
+          exe_path: ./dist
+          options: >-
+            --noconsole,
+            --onefile,
+            --name "Wabbajack fast downloader",
+          compression_level: 9
+          
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v1
         with:
-          body: |
-            ${{ github.event.head_commit.message }}
+          name: Release ${{ github.ref_name }}
+          body: ${{ github.event.head_commit.message }}
           draft: true
-          prerelease: false
-          files: build/${{ env.FILE_NAME }}.exe
+          files: ./dist/${{ env.FILE_NAME }}.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,15 @@ jobs:
             --noconsole,
             --onefile,
             --name "Wabbajack fast downloader",
-          compression_level: 9
+          compression_level: 0
           upload_exe_with_name: "Wabbajack fast downloader.exe"
-          
+        
+      - name: ls
+        run: ls -la ./dist
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:
           name: Release ${{ github.ref_name }}
           body: ${{ github.event.head_commit.message }}
           draft: true
-          files: ./dist/Wabbajack fast downloader.exe
+          files: ./dist/Wabbajack fast downloader

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
             --onefile,
             --name "Wabbajack fast downloader",
           compression_level: 9
+          upload_exe_with_name: "Wabbajack fast downloader.exe"
           
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
@@ -46,4 +47,4 @@ jobs:
           name: Release ${{ github.ref_name }}
           body: ${{ github.event.head_commit.message }}
           draft: true
-          files: ./dist/${{ env.FILE_NAME }}.exe
+          files: ./dist/Wabbajack fast downloader.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,13 +40,11 @@ jobs:
             --name "Wabbajack fast downloader",
           compression_level: 0
           upload_exe_with_name: "Wabbajack fast downloader.exe"
-        
-      - name: ls
-        run: ls ./dist
+
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:
           name: Release ${{ github.ref_name }}
           body: ${{ github.event.head_commit.message }}
           draft: true
-          files: ./dist/Wabbajack fast downloader
+          files: ./dist/Wabbajack fast downloader.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           upload_exe_with_name: "Wabbajack fast downloader.exe"
         
       - name: ls
-        run: ls -la ./dist
+        run: ls ./dist
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This pull request introduces several important changes to the GitHub Actions workflow configuration, including preventing concurrent releases and updating the build process for the Windows job. 

Enhancements to workflow configuration:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R8-R12): Added a `concurrency` group to prevent concurrent releases.

Updates to the Windows build job:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L18-R50): Replaced Nuitka with PyInstaller for building the application, including specifying PyInstaller options and updating the release creation step to handle the new build output.